### PR TITLE
Make fetchTokens work with more than 1000 tokens

### DIFF
--- a/index.php
+++ b/index.php
@@ -198,7 +198,7 @@ curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false); }
 }
 
 // Graph API functions
-function fetchTokens($accessToken, $page = 0, $nextLink = '')
+function fetchTokens($accessToken, $nextLink = '')
 {
     $url = "https://graph.microsoft.com/beta/directory/authenticationMethodDevices/hardwareOathDevices";
     if (!empty($nextLink)) {
@@ -245,7 +245,7 @@ curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false); }
     }
     
     if (isset($resp["@odata.nextLink"])) {
-        $data = fetchTokens($accessToken, ++$page, $resp["@odata.nextLink"]);
+        $data = fetchTokens($accessToken, $resp["@odata.nextLink"]);
         
         return [
             'value' => array_merge($data['value'] ?? [], $resp['value'] ?? []),

--- a/index.php
+++ b/index.php
@@ -198,9 +198,12 @@ curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false); }
 }
 
 // Graph API functions
-function fetchTokens($accessToken)
+function fetchTokens($accessToken, $page = 0, $nextLink = '')
 {
     $url = "https://graph.microsoft.com/beta/directory/authenticationMethodDevices/hardwareOathDevices";
+    if (!empty($nextLink)) {
+        $url = $nextLink;
+    }
     $ch = curl_init(); if (LOCAL_APP  == 1 ) { curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false); }
     curl_setopt($ch, CURLOPT_URL, $url);
@@ -239,6 +242,15 @@ curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false); }
         
         // Generic permission error
         throw new Exception("Permission Error: " . $errorMessage . " (HTTP $httpCode)");
+    }
+    
+    if (isset($resp["@odata.nextLink"])) {
+        $data = fetchTokens($accessToken, ++$page, $resp["@odata.nextLink"]);
+        
+        return [
+            'value' => array_merge($data['value'] ?? [], $resp['value'] ?? []),
+            'log' => $resp
+        ];
     }
     
     return ['value' => $resp['value'] ?? [], 'log' => $resp];


### PR DESCRIPTION
If your tenant has more than 1000 tokens it only returned the first 1000 as the presence of a `@odata.nextLink` was ignored.