### PR TITLE
Replace README copy in Generate-Token2Cert.ps1 with the actual script; add missing PS 5.1 variant

### DIFF
--- a/Generate-Token2Cert-51.ps1
+++ b/Generate-Token2Cert-51.ps1
@@ -1,0 +1,74 @@
+<#
+.SYNOPSIS
+    Generates a self-signed certificate for the TOTP Token Inventory app
+    (certificate-based authentication to Microsoft Entra ID).
+    Windows PowerShell 5.1 variant - uses OpenSSL.
+
+.DESCRIPTION
+    Produces the two files described in README section 6.F:
+
+      token2_public.cer  - public certificate to upload to your App
+                           Registration (Certificates & secrets ->
+                           Certificates -> Upload certificate)
+      private_key.pem    - matching private key (unencrypted PEM) for the
+                           app's "Private key file path" setting
+
+    It also prints the certificate SHA-1 thumbprint (hex) to paste into
+    the app.
+
+    OpenSSL generates the key directly in software, so no SafeNet /
+    Thales hardware-token dialog can appear. openssl.exe must be in PATH
+    (it ships with Git for Windows: C:\Program Files\Git\usr\bin).
+
+.NOTES
+    Treat private_key.pem like a password - anyone with it can
+    authenticate as your app. Store it outside the web root.
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File .\Generate-Token2Cert-51.ps1
+#>
+[CmdletBinding()]
+param(
+    [string]$SubjectName  = 'Token2 Inventory App',
+    [int]   $ValidityDays = 730,
+    [string]$CerPath      = (Join-Path (Get-Location) 'token2_public.cer'),
+    [string]$PemPath      = (Join-Path (Get-Location) 'private_key.pem')
+)
+
+$ErrorActionPreference = 'Stop'
+
+$openssl = Get-Command openssl -ErrorAction SilentlyContinue
+if (-not $openssl) {
+    Write-Error ("openssl.exe was not found in PATH. Install OpenSSL or add it to PATH " +
+        "(Git for Windows bundles it under C:\Program Files\Git\usr\bin), " +
+        "or use Generate-Token2Cert.ps1 with PowerShell 7+ instead.")
+    exit 1
+}
+
+Write-Host "Generating self-signed certificate (CN=$SubjectName, valid $ValidityDays days)..."
+
+& $openssl.Source req -x509 -newkey rsa:2048 -sha256 -days $ValidityDays -nodes `
+    -keyout $PemPath -out $CerPath -subj "/CN=$SubjectName" 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "OpenSSL failed to generate the certificate (exit code $LASTEXITCODE)."
+    exit 1
+}
+
+# SHA-1 fingerprint, e.g. "sha1 Fingerprint=A1:B2:..." -> "A1B2..."
+$fingerprintLine = & $openssl.Source x509 -in $CerPath -noout -fingerprint -sha1
+$thumbprint = ($fingerprintLine -split '=', 2)[1] -replace ':', ''
+
+Write-Host ''
+Write-Host 'Done.'
+Write-Host "  Public certificate : $CerPath  (upload this to Entra ID)"
+Write-Host "  Private key (PEM)  : $PemPath  (path goes into the app settings)"
+Write-Host "  Thumbprint         : $thumbprint"
+Write-Host ''
+Write-Host 'Next steps:'
+Write-Host '  1. Azure Portal -> App registrations -> your app -> Certificates & secrets'
+Write-Host '     -> Certificates -> Upload certificate -> select token2_public.cer'
+Write-Host '  2. Confirm the thumbprint shown by Entra ID matches the one above.'
+Write-Host '  3. In the app, set Authentication method = Certificate, enter the'
+Write-Host '     private key path and the thumbprint.'
+Write-Host ''
+Write-Host 'Keep private_key.pem secret and outside the web root.'

--- a/Generate-Token2Cert.ps1
+++ b/Generate-Token2Cert.ps1
@@ -1,179 +1,118 @@
-# TOTP Token Inventory: Automate Token2 Classic OATH Token Activation in Microsoft Entra ID
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Generates a self-signed certificate for the TOTP Token Inventory app
+    (certificate-based authentication to Microsoft Entra ID).
 
----
+.DESCRIPTION
+    Produces the two files described in README section 6.F:
 
-## **🚀 Key Feature: Automatic Token Activation**
-The **TOTP Token Inventory** app now supports **automatic activation** of Token2 Classic OATH tokens during CSV upload. When tokens are assigned to users in the CSV, the app will:
-- Retrieve the **secret key** of each token.
-- Calculate the **current OTP code** (for both SHA-1 and SHA-256).
-- Send the code to **Microsoft Graph API** for activation.
+      token2_public.cer  - public certificate (DER) to upload to your
+                           App Registration (Certificates & secrets ->
+                           Certificates -> Upload certificate)
+      private_key.pem    - matching private key (unencrypted PKCS#8 PEM)
+                           for the app's "Private key file path" setting
 
-This **eliminates the need for separate bulk activation tools**, making deployment **faster and more efficient**.
+    It also prints the certificate thumbprint (hex) to paste into the app.
 
----
+    The key is generated with the Microsoft software provider
+    ("Microsoft Enhanced RSA and AES Cryptographic Provider") on purpose:
+    if a SafeNet / Thales (or other hardware token) dialog would normally
+    appear, that means a hardware provider is the default on your machine.
+    Hardware-token-stored keys cannot be exported to PEM and are not
+    supported by this app.
 
-## **1. Overview**
-The **TOTP Token Inventory** app is a **powerful, open-source PHP tool** designed to **automate the management and activation** of **Token2 Classic OATH hardware tokens** in Microsoft Entra ID (Azure AD). Unlike Microsoft’s official tools, this app offers:
-- A **user-friendly web interface**.
-- **Bulk operations** (CSV/JSON import).
-- **Automatic token activation** during CSV upload.
-- **Self-service activation** for end users.
-- **SHA-1 and SHA-256 support**.
-- **Detailed logging** for auditing.
+.NOTES
+    Requires PowerShell 7+ on Windows. For Windows PowerShell 5.1 use
+    Generate-Token2Cert-51.ps1 (uses OpenSSL).
 
----
+    Treat private_key.pem like a password - anyone with it can
+    authenticate as your app. Store it outside the web root.
 
-## **2. Comparison: TOTP Token Inventory vs. Microsoft’s Official Tools**
+.EXAMPLE
+    pwsh -ExecutionPolicy Bypass -File .\Generate-Token2Cert.ps1
+#>
+[CmdletBinding()]
+param(
+    [string]$SubjectName  = 'Token2 Inventory App',
+    [int]   $ValidityDays = 730,
+    [string]$CerPath      = (Join-Path (Get-Location) 'token2_public.cer'),
+    [string]$PemPath      = (Join-Path (Get-Location) 'private_key.pem'),
+    # Keep the certificate (and key) in the CurrentUser\My store after export.
+    # By default it is removed, since the app only needs the PEM file.
+    [switch]$KeepInStore
+)
 
-| Feature                     | Microsoft CSV Blade (Admin Center) | Microsoft Graph API | TOTP Token Inventory (PHP App) |
-|-----------------------------|-----------------------------------|---------------------|--------------------------------|
-| **Automatic Activation**    | ❌ No                              | ❌ No                | ✅ **Yes** (during CSV upload) |
-| **Bulk Import**             | ✅ Yes (CSV only)                 | ✅ Yes               | ✅ **Yes** (CSV/JSON)          |
-| **Self-Service Activation** | ❌ No                              | ✅ Yes               | ✅ **Yes**                     |
-| **SHA-256 Support**         | ❌ No                              | ✅ Yes               | ✅ **Yes**                     |
-| **User-Friendly UI**         | ✅ Basic                           | ❌ No (API only)     | ✅ **Full Web UI**             |
-| **Detailed Logging**        | ❌ No                              | ❌ No                | ✅ **Yes**                     |
-| **No Scripting Required**   | ✅ Yes                             | ❌ No                | ✅ **Yes**                     |
-| **Open-Source**             | ❌ No                              | ❌ No                | ✅ **Yes**                     |
-| **Bundled Windows App**     | ❌ No                              | ❌ No                | ✅ **Yes**                     |
+$ErrorActionPreference = 'Stop'
 
----
+if (-not $IsWindows) {
+    Write-Error ("New-SelfSignedCertificate is only available on Windows. " +
+        "On Linux/macOS use OpenSSL instead:`n" +
+        '  openssl req -x509 -newkey rsa:2048 -keyout private_key.pem -out token2_public.cer -days 730 -nodes -subj "/CN=Token2 Inventory App"')
+    exit 1
+}
 
-## **3. Why Choose TOTP Token Inventory?**
-- **Automatic Activation**: The **only solution** that activates tokens during CSV import, eliminating manual steps.
-- **User-Friendly**: No scripting required; accessible via a **web UI**.
-- **Bulk Operations**: Import and assign **hundreds of tokens at once**.
-- **Self-Service**: Users activate tokens **without admin intervention**.
-- **SHA-256 Support**: Handles both **SHA-1 and SHA-256** tokens.
-- **Open-Source**: Free to use, modify, and deploy.
-- **Bundled App**: Run on **Windows without a server** using PHPDesktop.
+Write-Host "Generating self-signed certificate (CN=$SubjectName, valid $ValidityDays days)..."
 
----
+# -Provider forces the Microsoft software CSP so no hardware-token (SafeNet/
+# Thales) dialog appears and the key stays exportable to PEM.
+$cert = New-SelfSignedCertificate `
+    -Subject           "CN=$SubjectName" `
+    -KeyAlgorithm      RSA `
+    -KeyLength         2048 `
+    -HashAlgorithm     SHA256 `
+    -KeySpec           Signature `
+    -KeyExportPolicy   Exportable `
+    -Provider          'Microsoft Enhanced RSA and AES Cryptographic Provider' `
+    -NotAfter          (Get-Date).AddDays($ValidityDays) `
+    -CertStoreLocation 'Cert:\CurrentUser\My'
 
-## **4. Pre-Requisites**
-- **Server**: Works on **any server with PHP 7.4+** (Linux/Windows).
-- **Bundled App**: Also available as a **PHPDesktop-based Windows app** (no server required).
-- **Microsoft Entra ID**:
-  - **Tenant ID**, **Client ID**, and **either a Client Secret or a Certificate** (from an App Registration with **Graph API permissions**).
-  - **Authentication method**: The app supports **two ways** to authenticate the App Registration:
-    - **Client Secret** – the original, simplest method.
-    - **Certificate** – a **certificate-based credential** (signed JWT client assertion). More secure, as no shared secret is stored, and recommended for production. See **Section 6.F**.
-  - **Required permissions**:
-    - `Policy.ReadWrite.AuthenticationMethod`
-    - `UserAuthenticationMethod.ReadWrite.All`
-    - `User.Read.All`
-    - `Directory.Read.All`
-  - **Admin consent** for the above permissions.
-- **Token2 Classic Tokens**: **CSV file** with token details (serial number, secret key, UPN, etc.).
-  - **CSVs for factory-set seeds are provided by Token2** via the seed request procedure.
+try {
+    # Public certificate (DER .cer) for Entra ID
+    Export-Certificate -Cert $cert -FilePath $CerPath | Out-Null
 
----
+    # Private key as unencrypted PKCS#8 PEM (-----BEGIN PRIVATE KEY-----)
+    $rsa = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($cert)
+    try {
+        $pkcs8 = $rsa.ExportPkcs8PrivateKey()
+    }
+    catch {
+        # Some Windows key providers only allow encrypted export; round-trip
+        # through an encrypted blob to obtain the plain PKCS#8 bytes.
+        $pbe = [System.Security.Cryptography.PbeParameters]::new(
+            [System.Security.Cryptography.PbeEncryptionAlgorithm]::Aes256Cbc,
+            [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+            100000)
+        $tempPwd   = [Guid]::NewGuid().ToString()
+        $encrypted = $rsa.ExportEncryptedPkcs8PrivateKey($tempPwd, $pbe)
+        $plainRsa  = [System.Security.Cryptography.RSA]::Create()
+        $bytesRead = 0
+        $plainRsa.ImportEncryptedPkcs8PrivateKey($tempPwd, $encrypted, [ref]$bytesRead)
+        $pkcs8 = $plainRsa.ExportPkcs8PrivateKey()
+        $plainRsa.Dispose()
+    }
 
-## **5. Supported Formats**
+    $b64 = [Convert]::ToBase64String($pkcs8, [System.Base64FormattingOptions]::InsertLineBreaks)
+    $pem = "-----BEGIN PRIVATE KEY-----`n$b64`n-----END PRIVATE KEY-----`n"
+    Set-Content -Path $PemPath -Value $pem -Encoding ascii -NoNewline
+}
+finally {
+    if (-not $KeepInStore) {
+        Remove-Item -Path "Cert:\CurrentUser\My\$($cert.Thumbprint)" -DeleteKey -ErrorAction SilentlyContinue
+    }
+}
 
-| Format  | Use Case                                  | Description                                                                                     |
-|---------|-------------------------------------------|-------------------------------------------------------------------------------------------------|
-| **CSV**  | Bulk import with pre-assignment and **automatic activation** | Admins can **pre-assign tokens to users** in the CSV. The app **automatically activates** these tokens by calculating the OTP code and sending it to Graph API. **CSVs for factory-set seeds are provided by Token2**. |
-| **JSON** | Self-service repository                   | Tokens are uploaded to a **shared repository**. Users activate them via **Security Info**.     |
-
----
-
-## **6. Step-by-Step Guide**
-
-### **A. Initial Setup**
-1. **Download and install**:
-   - Deploy on a **PHP server** or use the **bundled Windows app**.
-2. **Enter credentials**:
-   - Provide your **Tenant ID** and **Client ID**.
-   - Choose an **Authentication method**: **Client Secret** or **Certificate** (see **Section 6.F** to set up a certificate).
-3. **Verify permissions**:
-   - Ensure the app has the required **Graph API permissions** and admin consent.
-
-### **B. Importing Tokens**
-1. **Prepare your CSV**:
-   - Include columns: `upn`, `serial number`, `secret key`, `timeinterval`, `manufacturer`, `model`.
-   - **Pre-assign tokens** by including user UPNs. The app will **automatically activate** these tokens.
-   - **CSVs for factory-set seeds are provided by Token2** via the seed request procedure.
-2. **Upload CSV/JSON**:
-   - Use the **web interface** to upload your file.
-   - The app **automatically converts CSV to JSON** for Graph API and **activates pre-assigned tokens**.
-
-### **C. Assigning Tokens**
-- **Search for users** and assign tokens via the **web UI**.
-- **Bulk assignment**: Assign multiple tokens at once using the CSV pre-assignment feature.
-
-### **D. Activating Tokens**
-- **Automatic activation**: When tokens are pre-assigned in the CSV, the app **automatically activates them** by calculating the OTP code and sending it to Graph API.
-- **User self-service**: Users activate tokens via the **web form** or their **Security Info page**.
-- **Auto-generation**: The app can **auto-generate TOTP codes** from the secret key for activation.
-
-### **E. Managing Tokens**
-- **Unassign/Delete**: Remove tokens from users or delete them permanently.
-- **Logs**: View detailed logs for all operations.
-
----
-
-### **F. Certificate-Based Authentication (Optional)**
-Instead of a **Client Secret**, you can authenticate the App Registration using a **certificate**. The app builds a **signed JWT client assertion** and sends it to Entra ID — no shared secret is stored on disk.
-
-**What you need:**
-- A **public certificate** (`.cer`) uploaded to your App Registration.
-- The matching **private key in PEM format** (`-----BEGIN PRIVATE KEY-----`), readable by the PHP process.
-- The certificate **thumbprint** (hex), shown by Entra ID after upload.
-
-**1. Generate a certificate (Windows, PowerShell):**
-
-Use the bundled helper script `Generate-Token2Cert.ps1` (PowerShell 7+) or `Generate-Token2Cert-51.ps1` (Windows PowerShell 5.1, uses OpenSSL):
-
-```powershell
-powershell -ExecutionPolicy Bypass -File .\Generate-Token2Cert.ps1
-```
-
-This produces:
-- `token2_public.cer` – the **public certificate** to upload to Entra ID.
-- `private_key.pem` – the **private key** for the app.
-- A printed **thumbprint** to paste into the app.
-
-> **Note:** If a **SafeNet / Thales token dialog** appears, it means a hardware-token provider is being used. The scripts force the **Microsoft software provider** (`-Provider "Microsoft Enhanced RSA and AES Cryptographic Provider"`) to avoid this. Hardware-token-stored keys cannot be exported to PEM and are not supported by this app.
-
-Alternatively, generate everything in one step with **OpenSSL**:
-
-```powershell
-openssl req -x509 -newkey rsa:2048 -keyout private_key.pem -out token2_public.cer -days 730 -nodes -subj "/CN=Token2 Inventory App"
-openssl x509 -in token2_public.cer -noout -fingerprint -sha1
-```
-
-**2. Upload the public certificate to Entra ID:**
-- Go to **Azure Portal → App registrations → your app → Certificates & secrets → Certificates → Upload certificate**.
-- Upload `token2_public.cer`.
-- Entra ID displays the **thumbprint** — confirm it matches the one printed by the script.
-
-**3. Configure the app:**
-- On the credentials screen (or **Settings**), set **Authentication method** to **Certificate**.
-- **Private key file path**: full path to `private_key.pem` (e.g. `C:\token2\private_key.pem`).
-- **Private key passphrase**: only if you created an **encrypted** PEM; otherwise leave blank.
-- **Certificate thumbprint**: paste the hex thumbprint.
-
-**4. Security notes:**
-- Treat `private_key.pem` like a password — anyone with it can authenticate as your app.
-- Store the key **outside the web root** when running on a web server.
-- A **self-signed certificate is sufficient**, because Entra ID trusts it by explicit upload (not by a CA chain).
-- Set a reminder before the certificate **expiry date** — token requests fail once it expires.
-
----
-
-## **7. Best Practices**
-- **Backup credentials**: Store your **Client Secret** or **private key (PEM)** securely.
-- **Prefer certificates in production**: Certificate-based auth avoids storing a shared secret and is generally more secure than a Client Secret.
-- **Test with a small batch**: Validate the workflow before bulk importing.
-- **Monitor logs**: Use logs to audit operations and troubleshoot issues.
-- **Keep permissions updated**: Ensure Graph API permissions are current.
-
----
-
-## **8. Conclusion**
-The **TOTP Token Inventory** app is the **only solution** that offers **automatic token activation** during CSV import, making it the **most efficient way** to deploy and manage **Token2 Classic OATH tokens** in Microsoft Entra ID. With its **user-friendly interface**, **bulk operations**, and **self-service activation**, it provides a **complete, scalable, and auditable** solution for organizations of all sizes.
-
-**Say goodbye to manual activation processes—TOTP Token Inventory automates everything.**
-
- 
+Write-Host ''
+Write-Host 'Done.'
+Write-Host "  Public certificate : $CerPath  (upload this to Entra ID)"
+Write-Host "  Private key (PEM)  : $PemPath  (path goes into the app settings)"
+Write-Host "  Thumbprint         : $($cert.Thumbprint)"
+Write-Host ''
+Write-Host 'Next steps:'
+Write-Host '  1. Azure Portal -> App registrations -> your app -> Certificates & secrets'
+Write-Host '     -> Certificates -> Upload certificate -> select token2_public.cer'
+Write-Host '  2. Confirm the thumbprint shown by Entra ID matches the one above.'
+Write-Host '  3. In the app, set Authentication method = Certificate, enter the'
+Write-Host '     private key path and the thumbprint.'
+Write-Host ''
+Write-Host 'Keep private_key.pem secret and outside the web root.'


### PR DESCRIPTION
## Problem

`Generate-Token2Cert.ps1` in the repository is not a PowerShell script — it is a byte-for-byte copy of `README.md` (`diff` shows the two files identical). Anyone following README section 6.F (Certificate-Based Authentication):

```powershell
powershell -ExecutionPolicy Bypass -File .\Generate-Token2Cert.ps1
```

gets a wall of parse errors, so the certificate auth feature cannot be set up with the bundled helper. The `Generate-Token2Cert-51.ps1` script the README also references (Windows PowerShell 5.1 / OpenSSL variant) is missing from the repository entirely. It looks like the wrong file content was uploaded in the commit that introduced it.

Fixes #12

## Changes

Implements both scripts exactly as the README describes:

**`Generate-Token2Cert.ps1`** (PowerShell 7+, Windows):
- `New-SelfSignedCertificate` with `-Provider "Microsoft Enhanced RSA and AES Cryptographic Provider"` so no SafeNet/Thales hardware-token dialog appears and the key stays exportable, as documented.
- Exports `token2_public.cer` (DER, for upload to Entra ID) and `private_key.pem` (unencrypted PKCS#8, `-----BEGIN PRIVATE KEY-----`, as expected by the app's `openssl_pkey_get_private()` / signed JWT client assertion flow).
- Prints the thumbprint to paste into the app, plus the next-step instructions.
- Removes the certificate from `Cert:\CurrentUser\My` after export (the app only needs the PEM); `-KeepInStore` opts out.
- Handles providers that only allow encrypted key export by round-tripping through an encrypted PKCS#8 blob.
- Parameters for subject name, validity days, and output paths (defaults match the README: `CN=Token2 Inventory App`, 730 days).

**`Generate-Token2Cert-51.ps1`** (Windows PowerShell 5.1):
- OpenSSL-based variant producing the same two files and printing the SHA-1 thumbprint (colons stripped, ready to paste).
- Clear error if `openssl.exe` is not in PATH, with a hint that Git for Windows bundles it.

## Notes for review

Written on a non-Windows machine, so please give the PS7 script one run on Windows before merging — in particular the `Export-Certificate`/key-export path. The OpenSSL variant mirrors the exact commands already shown in README section 6.F.
